### PR TITLE
fixed package name misspelled

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ node: v10
 
 #### Using npm
 ```sh
-npm install --save countries-capital
+npm install --save countries-capitals
 ```
 
 #### Using Yarn
@@ -36,7 +36,7 @@ yarn add countries-capital
 ## How to use
 
 ```js
-const Countries = require('countries-capital')
+const Countries = require('countries-capitals')
 const countries = new Countries()
 
 // filter by name
@@ -86,7 +86,7 @@ countries.capital // ...
 ## Full API Reference
 
 ```js
-const Countries = require('countries-capital')
+const Countries = require('countries-capitals')
 const countries = new Countries()
 
 // lists all the countries data disregading any filter


### PR DESCRIPTION
Fixed npm package name misspelled/bug that causes the following errors when installing the package:
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/countries-capital - Not found
npm ERR! 404
npm ERR! 404  'countries-capital@*' is not in this registry.
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
